### PR TITLE
Fixed model hip inertia pose

### DIFF
--- a/legs_with_upper_body/model.sdf
+++ b/legs_with_upper_body/model.sdf
@@ -3,7 +3,7 @@
         <link name="hip">
             <pose frame="">0 0 0.6 0 -0 0</pose>
             <inertial>
-                <pose frame="">0.074697 0.137093 0.149689 0 -0 0</pose>
+                <pose frame="">0.074697 -0.137093 0.149689 0 -0 0</pose>
                 <mass>0.912006</mass>
                 <inertia>
                     <ixx>0.00265949</ixx>


### PR DESCRIPTION
- The hip's inertia was strangely situated outside the visual model. Substituted the Y coordinate of the pose with it's negated value, which seemed to put the inertia exactly where it is supposed to be.